### PR TITLE
Add animated shader background and layout shell

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
-import ShaderBg from '@/components/ShaderBg';
+import ShaderBg from '@/components/ShaderBgClient';
 
 export const metadata: Metadata = {
   title: 'Polymuffin',
@@ -27,4 +27,3 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     </html>
   );
 }
-

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
+import ShaderBg from '@/components/ShaderBg';
 
 export const metadata: Metadata = {
   title: 'Polymuffin',
@@ -8,8 +9,22 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body className="min-h-screen bg-black text-white">{children}</body>
+    <html lang="it">
+      <body className="min-h-screen bg-transparent text-white">
+        <ShaderBg />
+        <div className="min-h-screen bg-black/30 backdrop-blur-sm">
+          <header className="max-w-6xl mx-auto px-6 py-5 flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              {/* LOGO placeholder */}
+              <div className="h-8 w-8 rounded-xl bg-emerald-400/80 blur-[1px]" />
+              <span className="font-semibold tracking-wide">Polymuffin</span>
+            </div>
+            {/* nav placeholder */}
+          </header>
+          <main className="max-w-6xl mx-auto px-6 pb-20">{children}</main>
+        </div>
+      </body>
     </html>
   );
 }
+

--- a/src/components/ShaderBg.tsx
+++ b/src/components/ShaderBg.tsx
@@ -1,17 +1,41 @@
 'use client';
-import dynamic from 'next/dynamic';
-const Canvas = dynamic(() => import('@shadergradient/react').then(m => m.ShaderGradientCanvas), { ssr: false });
-const Gradient = dynamic(() => import('@shadergradient/react').then(m => m.ShaderGradient), { ssr: false });
 
+import { useEffect, useState } from 'react';
+import { ShaderGradientCanvas, ShaderGradient } from '@shadergradient/react';
+
+/**
+ * Full-page animated background (updated preset).
+ * - pointer-events: none to keep UI clickable
+ * - zIndex: -1 to stay behind content
+ */
 export default function ShaderBg() {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
+
   return (
-    <div aria-hidden style={{ position:'fixed', inset:0, zIndex:-1, pointerEvents:'none' }}>
-      <Canvas style={{ width:'100%', height:'100%' }}>
-        <Gradient
+    <div
+      aria-hidden
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: -1,
+        pointerEvents: 'none',
+      }}
+    >
+      <ShaderGradientCanvas style={{ width: '100%', height: '100%' }}>
+        <ShaderGradient
           control="query"
-          urlString="https://www.shadergradient.co/customize?animate=on&bgColor1=%23070b11&bgColor2=%23070b11&brightness=1.1&cAzimuthAngle=180&cDistance=3.6&cPolarAngle=90&color1=%2352ff89&color2=%23dbba95&color3=%23d0bce1&lightType=3d&shader=defaults&type=plane&uDensity=1.15&uFrequency=5&uSpeed=0.35&uStrength=3.8&wireframe=false"
+          urlString="https://www.shadergradient.co/customize?animate=on&axesHelper=on&bgColor1=%23000000&bgColor2=%23000000&brightness=0.6&cAzimuthAngle=180&cDistance=3.9&cPolarAngle=115&cameraZoom=1&color1=%23ff0000&color2=%23000000&color3=%23000000&destination=onCanvas&embedMode=off&envPreset=city&format=gif&fov=45&frameRate=10&grain=off&lightType=3d&pixelDensity=1&positionX=-0.5&positionY=0.1&positionZ=0&range=disabled&rangeEnd=40&rangeStart=0&reflection=0.1&rotationX=0&rotationY=0&rotationZ=235&shader=defaults&type=waterPlane&uAmplitude=0&uDensity=1.1&uFrequency=5.5&uSpeed=0.1&uStrength=2.4&uTime=0.2&wireframe=false"
         />
-      </Canvas>
+      </ShaderGradientCanvas>
     </div>
   );
 }
+

--- a/src/components/ShaderBg.tsx
+++ b/src/components/ShaderBg.tsx
@@ -3,7 +3,7 @@
 import { ShaderGradientCanvas, ShaderGradient } from '@shadergradient/react';
 
 /**
- * Full-page animated background (bright red preset).
+ * Full-page animated background (updated preset).
  * - pointer-events: none to keep UI clickable
  * - zIndex: -1 to stay behind content
  */
@@ -21,7 +21,7 @@ export default function ShaderBg() {
       <ShaderGradientCanvas style={{ width: '100%', height: '100%' }}>
         <ShaderGradient
           control="query"
-          urlString="https://www.shadergradient.co/customize?animate=on&axesHelper=on&bgColor1=%23000000&bgColor2=%23040000&brightness=0.75&cAzimuthAngle=180&cDistance=3.9&cPolarAngle=115&cameraZoom=1&color1=%23ff2626&color2=%23000000&color3=%23000000&destination=onCanvas&embedMode=off&envPreset=city&format=gif&fov=45&frameRate=10&grain=off&lightType=3d&pixelDensity=1&positionX=-0.5&positionY=0.1&positionZ=0&range=disabled&rangeEnd=40&rangeStart=0&reflection=0&rotationX=0&rotationY=0&rotationZ=235&shader=defaults&type=waterPlane&uAmplitude=0&uDensity=1.1&uFrequency=5.5&uSpeed=0.1&uStrength=2.4&uTime=0.2&wireframe=false"
+          urlString="https://www.shadergradient.co/customize?animate=on&axesHelper=on&bgColor1=%23000000&bgColor2=%23000000&brightness=0.6&cAzimuthAngle=180&cDistance=3.9&cPolarAngle=115&cameraZoom=1&color1=%23ff0000&color2=%23000000&color3=%23000000&destination=onCanvas&embedMode=off&envPreset=city&format=gif&fov=45&frameRate=10&grain=off&lightType=3d&pixelDensity=1&positionX=-0.5&positionY=0.1&positionZ=0&range=disabled&rangeEnd=40&rangeStart=0&reflection=0.1&rotationX=0&rotationY=0&rotationZ=235&shader=defaults&type=waterPlane&uAmplitude=0&uDensity=1.1&uFrequency=5.5&uSpeed=0.1&uStrength=2.4&uTime=0.2&wireframe=false"
         />
       </ShaderGradientCanvas>
     </div>

--- a/src/components/ShaderBg.tsx
+++ b/src/components/ShaderBg.tsx
@@ -1,24 +1,13 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { ShaderGradientCanvas, ShaderGradient } from '@shadergradient/react';
 
 /**
- * Full-page animated background (updated preset).
+ * Full-page animated background using the updated preset.
  * - pointer-events: none to keep UI clickable
  * - zIndex: -1 to stay behind content
  */
 export default function ShaderBg() {
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  if (!mounted) {
-    return null;
-  }
-
   return (
     <div
       aria-hidden
@@ -38,4 +27,3 @@ export default function ShaderBg() {
     </div>
   );
 }
-

--- a/src/components/ShaderBg.tsx
+++ b/src/components/ShaderBg.tsx
@@ -3,7 +3,7 @@
 import { ShaderGradientCanvas, ShaderGradient } from '@shadergradient/react';
 
 /**
- * Full-page animated background using the updated preset.
+ * Full-page animated background (bright red preset).
  * - pointer-events: none to keep UI clickable
  * - zIndex: -1 to stay behind content
  */
@@ -21,7 +21,7 @@ export default function ShaderBg() {
       <ShaderGradientCanvas style={{ width: '100%', height: '100%' }}>
         <ShaderGradient
           control="query"
-          urlString="https://www.shadergradient.co/customize?animate=on&axesHelper=on&bgColor1=%23000000&bgColor2=%23000000&brightness=0.6&cAzimuthAngle=180&cDistance=3.9&cPolarAngle=115&cameraZoom=1&color1=%23ff0000&color2=%23000000&color3=%23000000&destination=onCanvas&embedMode=off&envPreset=city&format=gif&fov=45&frameRate=10&grain=off&lightType=3d&pixelDensity=1&positionX=-0.5&positionY=0.1&positionZ=0&range=disabled&rangeEnd=40&rangeStart=0&reflection=0.1&rotationX=0&rotationY=0&rotationZ=235&shader=defaults&type=waterPlane&uAmplitude=0&uDensity=1.1&uFrequency=5.5&uSpeed=0.1&uStrength=2.4&uTime=0.2&wireframe=false"
+          urlString="https://www.shadergradient.co/customize?animate=on&axesHelper=on&bgColor1=%23000000&bgColor2=%23040000&brightness=0.75&cAzimuthAngle=180&cDistance=3.9&cPolarAngle=115&cameraZoom=1&color1=%23ff2626&color2=%23000000&color3=%23000000&destination=onCanvas&embedMode=off&envPreset=city&format=gif&fov=45&frameRate=10&grain=off&lightType=3d&pixelDensity=1&positionX=-0.5&positionY=0.1&positionZ=0&range=disabled&rangeEnd=40&rangeStart=0&reflection=0&rotationX=0&rotationY=0&rotationZ=235&shader=defaults&type=waterPlane&uAmplitude=0&uDensity=1.1&uFrequency=5.5&uSpeed=0.1&uStrength=2.4&uTime=0.2&wireframe=false"
         />
       </ShaderGradientCanvas>
     </div>

--- a/src/components/ShaderBgClient.tsx
+++ b/src/components/ShaderBgClient.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const ClientShaderBg = dynamic(() => import('@/components/ShaderBg'), { ssr: false });
+
+export default function ShaderBgClient() {
+  return <ClientShaderBg />;
+}


### PR DESCRIPTION
## Summary
- add a reusable shader-based background component with updated gradient preset
- mount the background in the root layout alongside a translucent wrapper and simple header

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68dc2deb7ae88328a2c0d0d4158c363b