### PR TITLE
Adjust shader background lighting configuration

### DIFF
--- a/src/components/ShaderBg.tsx
+++ b/src/components/ShaderBg.tsx
@@ -21,7 +21,7 @@ export default function ShaderBg() {
       <ShaderGradientCanvas style={{ width: '100%', height: '100%' }}>
         <ShaderGradient
           control="query"
-          urlString="https://www.shadergradient.co/customize?animate=on&axesHelper=on&bgColor1=%23000000&bgColor2=%23000000&brightness=0.6&cAzimuthAngle=180&cDistance=3.9&cPolarAngle=115&cameraZoom=1&color1=%23ff0000&color2=%23000000&color3=%23000000&destination=onCanvas&embedMode=off&envPreset=city&format=gif&fov=45&frameRate=10&grain=off&lightType=3d&pixelDensity=1&positionX=-0.5&positionY=0.1&positionZ=0&range=disabled&rangeEnd=40&rangeStart=0&reflection=0.1&rotationX=0&rotationY=0&rotationZ=235&shader=defaults&type=waterPlane&uAmplitude=0&uDensity=1.1&uFrequency=5.5&uSpeed=0.1&uStrength=2.4&uTime=0.2&wireframe=false"
+          urlString="https://www.shadergradient.co/customize?animate=on&axesHelper=on&bgColor1=%23000000&bgColor2=%23000000&brightness=0.75&cAzimuthAngle=180&cDistance=3.9&cPolarAngle=115&cameraZoom=1&color1=%23ff3500&color2=%230a0000&color3=%23000000&destination=onCanvas&embedMode=off&envPreset=studio&format=gif&fov=45&frameRate=10&grain=off&lightType=basic&pixelDensity=1&positionX=-0.5&positionY=0.1&positionZ=0&range=disabled&rangeEnd=40&rangeStart=0&reflection=0&rotationX=0&rotationY=0&rotationZ=235&shader=defaults&type=waterPlane&uAmplitude=0&uDensity=1.1&uFrequency=5.5&uSpeed=0.1&uStrength=2.4&uTime=0.2&wireframe=false"
         />
       </ShaderGradientCanvas>
     </div>


### PR DESCRIPTION
## Summary
- switch the shader background to a studio environment with basic lighting and no reflections
- retune brightness and color palette values to keep visual depth without reflective highlights

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68dc37d4253c832885403f5f79845d2e