### PR TITLE
Enhance navigation visuals and KPI cards

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -2,6 +2,8 @@
 import * as React from 'react';
 import { Command } from 'cmdk';
 import { useRouter } from 'next/navigation';
+import { LayoutDashboard, LineChart, Search } from 'lucide-react';
+import Icon from './ui/Icon';
 
 export default function CommandPalette() {
   const r = useRouter();
@@ -27,6 +29,17 @@ export default function CommandPalette() {
     }
   }, [open]);
 
+  const navigationCommands = [
+    { label: 'Overview', href: '/', icon: LayoutDashboard },
+    { label: 'Search', href: '/search', icon: Search },
+    { label: 'Markets', href: '/markets', icon: LineChart },
+  ];
+  const quickQueries = [
+    { label: 'Search: bitcoin', href: '/search?q=bitcoin', icon: Search },
+    { label: 'Search: USA', href: '/search?q=USA', icon: Search },
+    { label: 'Search: USA→CHN', href: '/search?q=USA→CHN', icon: Search },
+  ];
+
   return (
     <div className={open ? '' : 'hidden'}>
       <div className="fixed inset-0 bg-black/60 z-50" onClick={() => setOpen(false)} />
@@ -48,14 +61,28 @@ export default function CommandPalette() {
           <Command.List className="max-h-[50vh] overflow-y-auto">
             <Command.Empty>No results found.</Command.Empty>
             <Command.Group heading="Navigation">
-              <Command.Item onSelect={() => navigate('/')}>Overview</Command.Item>
-              <Command.Item onSelect={() => navigate('/search')}>Search</Command.Item>
-              <Command.Item onSelect={() => navigate('/markets')}>Markets</Command.Item>
+              {navigationCommands.map((cmd) => (
+                <Command.Item
+                  key={cmd.href}
+                  onSelect={() => navigate(cmd.href)}
+                  className="flex items-center gap-3 data-[selected]:bg-white/10 data-[selected]:text-white"
+                >
+                  <Icon I={cmd.icon} className="h-4 w-4 text-white/80" />
+                  <span>{cmd.label}</span>
+                </Command.Item>
+              ))}
             </Command.Group>
             <Command.Group heading="Quick queries">
-              <Command.Item onSelect={() => navigate('/search?q=bitcoin')}>Search: bitcoin</Command.Item>
-              <Command.Item onSelect={() => navigate('/search?q=USA')}>Search: USA</Command.Item>
-              <Command.Item onSelect={() => navigate('/search?q=USA→CHN')}>Search: USA→CHN</Command.Item>
+              {quickQueries.map((cmd) => (
+                <Command.Item
+                  key={cmd.href}
+                  onSelect={() => navigate(cmd.href)}
+                  className="flex items-center gap-3 data-[selected]:bg-white/10 data-[selected]:text-white"
+                >
+                  <Icon I={cmd.icon} className="h-4 w-4 text-brand-red/80" />
+                  <span>{cmd.label}</span>
+                </Command.Item>
+              ))}
             </Command.Group>
           </Command.List>
         </Command>

--- a/src/components/KpiCard.tsx
+++ b/src/components/KpiCard.tsx
@@ -1,6 +1,18 @@
-import type { ReactNode } from 'react';
+import { useId } from 'react';
+import type { LucideIcon } from 'lucide-react';
 import Card from './ui/Card';
 import Badge from './ui/Badge';
+import Icon from './ui/Icon';
+
+type Accent = 'red';
+
+const accentTokens: Record<Accent, { badge: string; icon: string; sparkline: string }> = {
+  red: {
+    badge: 'bg-gradient-to-br from-brand-red/40 to-brand-red-soft/20 text-brand-red',
+    icon: 'text-brand-red',
+    sparkline: 'text-brand-red/70',
+  },
+};
 
 export default function KpiCard({
   label,
@@ -8,13 +20,18 @@ export default function KpiCard({
   delta,
   icon,
   badge,
+  accent = 'red',
 }: {
   label: string;
   value: string;
   delta?: string;
-  icon?: ReactNode;
+  icon?: LucideIcon;
   badge?: string;
+  accent?: Accent;
 }) {
+  const theme = accentTokens[accent];
+  const sparklineId = useId();
+
   return (
     <Card className="p-4">
       <div className="flex items-start justify-between gap-3">
@@ -26,10 +43,45 @@ export default function KpiCard({
             </div>
           )}
         </div>
-        {icon}
+        {icon && (
+          <span className={`relative grid h-12 w-12 place-items-center overflow-hidden rounded-full ${theme.badge}`}>
+            <span className="absolute inset-[1px] rounded-full bg-white/5" aria-hidden />
+            <Icon I={icon} className={`relative z-10 h-5 w-5 ${theme.icon}`} />
+          </span>
+        )}
       </div>
       <div className="mt-3 text-2xl font-semibold text-white">{value}</div>
       {delta && <div className="mt-2 text-xs text-brand-red/70">{delta}</div>}
+      <svg
+        className={`mt-4 h-12 w-full ${theme.sparkline}`}
+        viewBox="0 0 120 48"
+        role="presentation"
+        aria-hidden
+      >
+        <defs>
+          <linearGradient id={`${sparklineId}-stroke`} x1="0%" x2="100%" y1="0%" y2="0%">
+            <stop offset="0%" stopColor="currentColor" stopOpacity="0.6" />
+            <stop offset="100%" stopColor="currentColor" stopOpacity="0.1" />
+          </linearGradient>
+          <linearGradient id={`${sparklineId}-fill`} x1="0%" x2="0%" y1="0%" y2="100%">
+            <stop offset="0%" stopColor="currentColor" stopOpacity="0.2" />
+            <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <path
+          d="M2 36L18 26L34 32L50 14L66 18L82 8L98 18L114 4"
+          fill="none"
+          stroke={`url(#${sparklineId}-stroke)`}
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M2 36L18 26L34 32L50 14L66 18L82 8L98 18L114 4L114 46L2 46Z"
+          stroke="none"
+          fill={`url(#${sparklineId}-fill)`}
+        />
+      </svg>
     </Card>
   );
 }

--- a/src/components/RightColumn.tsx
+++ b/src/components/RightColumn.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from 'react';
+import { MessageCircle, TrendingUp } from 'lucide-react';
 import Card from './ui/Card';
 import Badge from './ui/Badge';
+import Icon from './ui/Icon';
 
 export function RightColumn({
   tweets,
@@ -31,10 +33,18 @@ export function RightColumn({
         {tweets.length ? (
           <ul className="space-y-3">
             {tweets.map((tweet) => (
-              <li key={tweet.id} className="rounded-xl border border-line-subtle/10 bg-white/5 p-3">
-                <div className="text-sm text-white/90">{tweet.text}</div>
-                <div className="text-xs text-text-secondary mt-2">
-                  {tweet.author} · ❤ {tweet.likes ?? 0}
+              <li
+                key={tweet.id}
+                className="flex items-start gap-3 rounded-xl border border-line-subtle/10 bg-white/5 p-3"
+              >
+                <span className="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-white/8 text-brand-red">
+                  <Icon I={MessageCircle} className="h-4 w-4" />
+                </span>
+                <div className="space-y-2">
+                  <div className="text-sm text-white/90">{tweet.text}</div>
+                  <div className="text-xs text-text-secondary">
+                    {tweet.author} · ❤ {tweet.likes ?? 0}
+                  </div>
                 </div>
               </li>
             ))}
@@ -51,12 +61,23 @@ export function RightColumn({
         </div>
         {markets.length ? (
           <ul className="space-y-3">
-            {markets.map((market) => (
-              <li key={market.id} className="rounded-xl border border-line-subtle/10 bg-white/5 p-3">
-                <div className="text-sm text-white/90">{market.question}</div>
-                <div className="text-xs text-text-secondary mt-2">
-                  {typeof market.price === 'number' ? `Price: ${market.price.toFixed(2)}` : '—'}
-                  {typeof market.volume === 'number' ? ` · Vol: ${Intl.NumberFormat().format(market.volume)}` : ''}
+            {markets.map((market, index) => (
+              <li
+                key={market.id}
+                className="flex items-start gap-3 rounded-xl border border-line-subtle/10 bg-white/5 p-3"
+              >
+                <span className="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-white/8 text-sm font-semibold text-white/80">
+                  {index + 1}
+                </span>
+                <div className="flex-1 space-y-2">
+                  <div className="flex items-center gap-2 text-sm text-white/90">
+                    <Icon I={TrendingUp} className="h-4 w-4 text-brand-red/80" />
+                    <span>{market.question}</span>
+                  </div>
+                  <div className="text-xs text-text-secondary">
+                    {typeof market.price === 'number' ? `Price: ${market.price.toFixed(2)}` : '—'}
+                    {typeof market.volume === 'number' ? ` · Vol: ${Intl.NumberFormat().format(market.volume)}` : ''}
+                  </div>
                 </div>
               </li>
             ))}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,12 +2,14 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
+import { LayoutDashboard, LineChart, Search } from 'lucide-react';
 import Card from '@/components/ui/Card';
+import Icon from '@/components/ui/Icon';
 
-const items = [
-  { href: '/', label: 'Overview' },
-  { href: '/search', label: 'Search' },
-  { href: '/markets', label: 'Markets' },
+const navItems = [
+  { href: '/', label: 'Overview', icon: LayoutDashboard },
+  { href: '/search', label: 'Search', icon: Search },
+  { href: '/markets', label: 'Markets', icon: LineChart },
 ];
 
 export default function Sidebar() {
@@ -21,16 +23,32 @@ export default function Sidebar() {
         </div>
       </Card>
       <Card className="p-2">
-        <nav>
-          {items.map(it => (
-            <Link key={it.href}
-              href={it.href}
-              className={clsx(
-                'block px-3 py-2 rounded-lg text-sm',
-                pathname === it.href ? 'bg-white/10 text-white' : 'text-text-secondary hover:bg-white/5'
-              )}
-            >{it.label}</Link>
-          ))}
+        <nav className="flex flex-col gap-1">
+          {navItems.map((item) => {
+            const isActive = pathname === item.href;
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={clsx(
+                  'relative flex items-center gap-3 rounded-lg pr-3 pl-6 py-2 text-sm transition before:absolute before:left-2 before:top-1/2 before:h-8 before:w-1 before:-translate-y-1/2 before:rounded-full before:bg-brand-red before:opacity-0 before:transition before:content-[""]',
+                  isActive
+                    ? 'bg-white/10 text-white before:opacity-100'
+                    : 'text-text-secondary hover:bg-white/5 hover:text-white before:bg-brand-red/40'
+                )}
+              >
+                <span
+                  className={clsx(
+                    'flex h-9 w-9 items-center justify-center rounded-full border border-white/5 bg-white/[0.07] transition',
+                    isActive ? 'border-white/20 text-white' : 'text-white/80'
+                  )}
+                >
+                  <Icon I={item.icon} className="h-4 w-4" />
+                </span>
+                <span>{item.label}</span>
+              </Link>
+            );
+          })}
         </nav>
       </Card>
       <Card className="p-4 text-sm text-text-secondary">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,6 +17,7 @@ const config: Config = {
         brand: {
           red: 'rgb(var(--brand-red) / <alpha-value>)',
           redSoft: 'rgb(var(--brand-red-soft) / <alpha-value>)',
+          'red-soft': 'rgb(var(--brand-red-soft) / <alpha-value>)',
         },
         line: {
           subtle: 'rgb(var(--line-subtle) / <alpha-value>)',


### PR DESCRIPTION
## Summary
- add lucide icons and accent bar styling to the sidebar navigation and command palette
- extend KPI cards with accent theming, icon badges, and a sparkline placeholder
- enrich right column tweet and market lists with iconography and numeric spines; add token alias for gradients

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd005602c88328a359861cf3c88a5b